### PR TITLE
add 'type=module' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,5 +54,6 @@
   },
   "publishConfig": {
     "access": "public"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
Fix for issue https://github.com/vinicoder/tw-to-css/issues/7 (SyntaxError: Unexpected token 'export')

A package.json "type" value of "module" tells Node.js to interpret .js files within that package as using ES module syntax.

