### PR TITLE
add: intellisense support section in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,11 +169,7 @@ Output:
 To make Tailwind Intellisense on VS Code recognize tw-to-css, just add the following code to your `settings.json` file:
 
 ```json
-{
-  // ...
-  "tailwindCSS.experimental.classRegex": [
-    ["twj\\(\\s*[\"'`]([^\"]*)[\"'`]\\s*\\)"]
-    ]
-  // ...
-}
+"tailwindCSS.experimental.classRegex": [
+  ["twj\\(\\s*[\"'`]([^\"]*)[\"'`]\\s*\\)"]
+]
 ```

--- a/README.md
+++ b/README.md
@@ -161,3 +161,19 @@ Output:
 </html>
 */
 ```
+
+## Intellisense Support
+
+### VS Code
+
+To make Tailwind Intellisense on VS Code recognize tw-to-css, just add the following code to your `settings.json` file:
+
+```json
+{
+  // ...
+  "tailwindCSS.experimental.classRegex": [
+    ["twj\\(\\s*[\"'`]([^\"]*)[\"'`]\\s*\\)"]
+    ]
+  // ...
+}
+```


### PR DESCRIPTION
Documentation section about making vs code recognize the package and provide the necessary tailwindcss autocompletion and suggestions